### PR TITLE
New documentation to help user/devs get started

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -29,6 +29,7 @@ export default defineConfig({
             { label: "PNPM", link: "/getting-started/pnpm" },
             { label: "Docs", link: "/getting-started/docs" },
             { label: "Generate Schema", link: "/getting-started/generate-schema" },
+            { label: "Improvements", link: "/getting-started/improvements" }
           ],
         },
         {

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -28,6 +28,7 @@ export default defineConfig({
             { label: "Introduction", link: "/" },
             { label: "PNPM", link: "/getting-started/pnpm" },
             { label: "Docs", link: "/getting-started/docs" },
+            { label: "Generate Schema", link: "/getting-started/generate-schema" },
           ],
         },
         {

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -26,6 +26,7 @@ export default defineConfig({
           label: "Start Here",
           items: [
             { label: "Introduction", link: "/" },
+            { label: "PNPM", link: "/getting-started/pnpm" },
           ],
         },
         {

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -24,7 +24,9 @@ export default defineConfig({
       sidebar: [
         {
           label: "Start Here",
-          items: [{ label: "Getting Started", link: "/" }],
+          items: [
+            { label: "Introduction", link: "/" },
+          ],
         },
         {
           label: "Options",

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -27,6 +27,7 @@ export default defineConfig({
           items: [
             { label: "Introduction", link: "/" },
             { label: "PNPM", link: "/getting-started/pnpm" },
+            { label: "Docs", link: "/getting-started/docs" },
           ],
         },
         {

--- a/docs/src/content/docs/getting-started/docs.mdx
+++ b/docs/src/content/docs/getting-started/docs.mdx
@@ -1,0 +1,30 @@
+---
+title: "Documentation"
+author: "tonygravagno"
+---
+
+## The docs folder
+
+The project includes a sub-project in the 'docs' folder. It contains the documentation that you are reading now.
+
+Using this in-project documentation is completely optional. You may prefer to use the [online version](https://mysql-to-zod.pages.dev/).
+
+**If you choose to use this in-project documentation ...**
+
+This is built and run separately from the mysql-to-zod project.
+
+The documentation project is based on [Astro](https://astro.build/), which uses local .mdx files (slightly enhanced Markdown) to generate a local website that hosts the documentation.
+
+## Setup
+
+After you [install PNPM](/getting-started/pnpm), open a terminal to the 'docs' folder, and `pnpm install` to load node_modules with all dependencies, including Astro. (Or use the familiar `npm` if you prefer.)
+
+## Generate deployable docs
+
+Build the docs project using the script in package.json.
+
+## View the docs in the browser
+
+Run the docs project using the "dev" or "start" script in package.json. In this mode the doc pages refresh as files are saved in the project.
+
+Open a browser and connect to the URL provided in the console. You can use the information there to guide you through setting the configuration file and generating your schema.

--- a/docs/src/content/docs/getting-started/generate-schema.mdx
+++ b/docs/src/content/docs/getting-started/generate-schema.mdx
@@ -1,0 +1,37 @@
+---
+title: "Generate Schema"
+author: "tonygravagno"
+---
+
+## Configuration File
+
+Use file mysqlToZod.config.js to define the data source and format of the schema output.
+
+Copy the original mysqlToZod.config.js to a backup.
+
+Walk through the documentation [Options](/options/config) pages to configure the .config.js file for your database and output requirements.
+
+## Run to generate
+
+Run the project using the script in package.json.
+
+Unless there are errors you should see a new schema file in the outputDir and fileName(s) specified in the config file.
+
+## Verify, Modify, Repeat
+
+Check the schema .ts files to ensure they contain the data desired, and in the desired format.
+
+- Are all required tables included?
+- Did you want table and field comments in the schema?
+- Is the usage of "nullish" and "nullable" acceptable?
+- Are the names for schema constants and types correct?
+- Is casing correct for your application?
+- Are more replacement settings required to modify table/schema names or field names?
+
+If required, change the config file and re-run the generation process.
+
+You may find that the schema in the database is missing comments, or that the database schema itself needs small changes to type or constraint details. This is one of the benefits of this exercise. If required, alter the database and re-run the generation process.
+
+## Reproducibility
+
+When the generation process is complete and you have usable code, save the mysqlToZod.config.js file and document it (however you wish) to ensure that the exact same process can be repeated. It's typical to get in to code and need to come back later to add tables, update the schema based on database changes, or to mass-change details for all schema for a specific application.

--- a/docs/src/content/docs/getting-started/improvements.mdx
+++ b/docs/src/content/docs/getting-started/improvements.mdx
@@ -1,0 +1,28 @@
+---
+title: "Improvements to mysql-to-zod"
+author: "tonygravagno"
+---
+
+## Offer your ideas
+
+As you use mysql-to-zod you may have ideas for enhancements, to add new details to schema that benefit applications.
+
+Ideas might include:
+
+- the addition of more type information
+- extending from base types
+- using interfaces
+- enhancements to the use of globalSchema or other base details
+- generating base classes
+- more complex replacements
+- use of new Zod features
+- a new output type to facilitate post-processing
+
+Just remember that the focus of this project is to read schema from MySQL and to write TypeScript files with Zod schema definitions. This is a very specific focus that might not include other functionality, like reading from another database or generating UI components.
+
+
+## GitHub
+
+Ideas, Q&A, and notes about your projects are welcome in [GitHub Discussions](https://github.com/araera111/mysql-to-zod/discussions).
+
+Please submit enhancement requests and bug reports to the [GitHub repo](https://github.com/araera111/mysql-to-zod/issues).

--- a/docs/src/content/docs/getting-started/pnpm.mdx
+++ b/docs/src/content/docs/getting-started/pnpm.mdx
@@ -1,0 +1,62 @@
+---
+title: "PNPM Package Manager"
+author: "tonygravagno"
+---
+
+## What is it?
+
+This project uses [PNPM](https://github.com/pnpm/pnpm) for package management. PNPM is exactly like NPM, just optimized.
+
+You do not need PNPM to use this project - you can use `npm`. But if this is your first introduction to PNPM, it's very simple but very efficient, and this would be a great project to get started using it.
+
+PNPM stores all packages in a common location, rather than directly in the 'node_modules' folder of every project.
+
+When you install a package it checks the common location for that package+version. If it doesn't exist, it's loaded to the common location. When it exists, a link is set from 'node_modules' to the common location. Software at the exact same version isn't copied to multiple projects.
+
+### General Information
+
+#### Install PNPM
+
+- `npm install -g pnpm`
+- Then use `pnpm` rather than `npm` for all operations or wherever you choose.
+
+#### Configuration notes
+
+Minor configuration of PNPM is required. You can run `pnpm setup` and allow that process to automatically set its parameters and your PATH to point to required folders. Or you can customize the setup with these notes. Close your IDE before making environment changes.
+
+The `pnpm` command is installed in the folder with `npm`, `npx`, and other related commands. It's configuration includes setting parameters "global-bin-dir" and "store-dir".
+
+**global-bin-dir** is the location where pnpm saves its own commands. It's similar to the folder where NPM saves its commands. In fact, this folder can be under that folder. For example:
+
+- C:\Users\you\AppData\Roaming\npm
+- C:\Users\you\AppData\Roaming\npm\global-bin-dir
+
+You can set this folder manually. Create a folder and then execute this command:
+
+`pnpm config set global-bin-dir "C:\Users\you\AppData\Roaming\npm\global-bin-dir"`
+
+Also, add that folder to your user PATH.
+
+**store-dir** is the location where all of the common node_modules packages are stored.
+
+You can set this folder manually. Create a folder and then execute this command:
+
+`pnpm config set store-dir "D:\path\.pnpm-store"`
+
+(A 'v3' folder tree is created under that folder.)
+
+Also, add that folder to your user PATH.
+
+#### Existing projects
+
+In an existing project, just delete the 'node_modules' folder and `pnpm install`. This uses the existing package.json and lock file to install packages to the new location, and link from the local 'node_modules' folder.
+
+Once pnpm is installed, `pnpm install` to load 'node_modules' with all dependencies.
+
+### Specific to this project
+
+- Install PNPM as noted above or use NPM for package management.
+- Open a terminal in this project's root folder and `pnpm install`.
+- `cd` to /docs and `pnpm install`.
+
+You should now be ready to view docs and use this project.

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -7,15 +7,15 @@ author: "araera111"
 
 mysql-to-zod is a tool that generates Zod type definitions from MySQL table definitions.
 
-### Usage
+## Usage
 
 ```bash
 npx mysql-to-zod mysql://user:password@localhost:3306/dbname
 ```
 
-The above command will generate a type definition of zod in `. /mysqlToZod/schema.ts` will generate a type definition for zod.
+The above command will generate Zod-specific type definitions of all tables in "dbname", saving the new TypeScript code in `./mysqlToZod/schema.ts`.
 
-### Example
+## Example
 
 Suppose DB: my_todo has the following table definitions.
 
@@ -30,7 +30,7 @@ CREATE TABLE todo (
 );
 ```
 
-From the above table definition, the following zod schema is generated.
+From the above table definition, the following Zod schema is generated.
 
 ```typescript
 import { z } from "zod";
@@ -45,13 +45,10 @@ export const todoSchema = z.object({
 export type Todo = z.infer<typeof todoSchema>;
 ```
 
-These are the basic instructions for use.
-In many cases the above is all that is needed, but there are options that can be customized.
-For example, if you want the variable name to be `TODO_SCHEMA` instead of `todoSchema`.
+## Summary
 
-For more detailed options, please see the next page.
+These are the basic instructions for use. In many cases the above is all that is needed.  
+But with extensive [options](/options/config) many details can be customized.
+For example, you may want the variable name to be `TODO_SCHEMA` instead of `todoSchema`.
 
-## Notice
-
-If you have any questions about usage or suggestions for improvement, please visit disucussions.
-[Disucussions](https://github.com/araera111/mysql-to-zod/discussions)
+Please visit [Discussions](https://github.com/araera111/mysql-to-zod/discussions) for all questions about usage, and suggestions for improvement.


### PR DESCRIPTION
I added new pages to help someone to get started with this project. My motivation for new docs: I recently re-opened the repo and found many new things here. I was confused about some details, so as I re-acclimated I documented what was required to understand the project and move quickly to productivity.

- Everything is under the existing Start Here category.
- Modifed "Getting Started" header to "Introduction" - the category "Start Here" opens the topic of getting started and this page serves as the introduction to the project and this documentation.
- PNPM : New page helps developers to get started with PNPM for this project if they have never used it. It's made clear that it is not a requirement for user/developers, but this is what the package developer uses.
- Docs : New page describes this documentation and how to build and open it. For someone new to Astro, or projects within projects, this sub-project might be cryptic.
- Generate Schema : New page helps the new user to understand the flow of using this software.
- Improvements : New page dedicated to helping user/developer to understand the kind of suggestions that may help this project.
- Final changes/improvements to original index.

All updates have been made in separate commits for easier cherry picking, if desired.