### PR TITLE
Separate composition of Zod schema for column

### DIFF
--- a/src/process/buildSchemaText/utils/buildSchemaTextUtil.ts
+++ b/src/process/buildSchemaText/utils/buildSchemaTextUtil.ts
@@ -320,6 +320,16 @@ export const composeColumnStringList = ({
 	const { comment, nullable, type, autoIncrement } = column;
 	const { comments } = option;
 
+	const zodType = convertToZodType({
+		type,
+		option,
+	})
+	const maybeNullable = addNullType({ nullable, option, mode, autoIncrement })
+    // add other schema details here
+
+	// assemble final schema string
+	const zodSchema = zodType + maybeNullable;
+
 	const result: string[] = [
 		getCommentString({
 			comment,
@@ -327,10 +337,7 @@ export const composeColumnStringList = ({
 			column,
 			option,
 		}),
-		`${addSingleQuotation(column.column)}: ${convertToZodType({
-			type,
-			option,
-		})}${addNullType({ nullable, option, mode, autoIncrement })},\n`,
+		`${addSingleQuotation(column.column)}: ${zodSchema},\n`,
 	].flatMap((x) => (G.isNullable(x) ? [] : [x]));
 
 	return result;


### PR DESCRIPTION
This small change does nothing to change functionality. It simply pulls the building of the Zod schema ( `foo().bar().baz()` ) from the block that builds the text string ( `'name': foo().bar().baz(),\n` ).

The intent of this housekeeping is to prepare for adding new schema features without cluttering the line that builds the string literal. I intend to add new features here, at `// add other schema details here`. This will allow for that without future changes to the string literal.